### PR TITLE
docs: Fix simple typo, retrived -> retrieved

### DIFF
--- a/hackathon_starter/hackathon/scripts/googlePlus.py
+++ b/hackathon_starter/hackathon/scripts/googlePlus.py
@@ -68,7 +68,7 @@ class GooglePlus:
 
 		Parameters:
 			code: string
-				- The code is retrived from the authorization URL parameter 
+				- The code is retrieved from the authorization URL parameter 
 				to obtain access token.
 			state: string
 				- The unique session ID.

--- a/hackathon_starter/hackathon/scripts/scraper.py
+++ b/hackathon_starter/hackathon/scripts/scraper.py
@@ -10,7 +10,7 @@ from bs4 import BeautifulSoup
 
 def fetchHTML(url):
     '''
-    Returns HTML retrived from a url.
+    Returns HTML retrieved from a url.
 
     Parameters:
         url: String


### PR DESCRIPTION
There is a small typo in hackathon_starter/hackathon/scripts/googlePlus.py, hackathon_starter/hackathon/scripts/scraper.py.

Should read `retrieved` rather than `retrived`.

